### PR TITLE
2408.03314 paper summary added

### DIFF
--- a/papers/2408.03314_Scaling_LLM_Test_Time_Compute_Optimally_can_be_More_Effective_than_Scaling_Model_Parameters.md
+++ b/papers/2408.03314_Scaling_LLM_Test_Time_Compute_Optimally_can_be_More_Effective_than_Scaling_Model_Parameters.md
@@ -1,0 +1,84 @@
+# [Scaling LLM Test-Time Compute Optimally can be More Effective than Scaling Model Parameters](https://arxiv.org/abs/2408.03314)
+
+ID: Issue #338
+
+
+## Summary
+
+This paper compares pre-training with inference-time approaches 
+such as reward models and refinement techniques combined with various tree search algorithms
+to achieve better compute-tradeoff during pre-training vs inference.
+Instead of expensive human annotation, the method runs Monte Carlo roll-outs
+from each step in the solution to estimate the per-step correctness 
+for generating PRM labels.
+During generating the revision data, the the method uses 
+temperature sampling for generating multi-turn rollout post-hoc and 
+utilizes character edit distance
+to prioritize incorrect answers correlated with the final correct answer.
+Moreover, the authors proposes to use pass@1 rate 
+to estimate the difficulty category of the questions instead of hand-labelling.
+
+
+## Relevance to survey topic (1-5)
+
+Relevance: 4
+
+Highly relevant as the paper proposes to use synthetic dataset and diversity metrics
+during the training data preparation for reward model, verifier model and difficulty estimation.
+
+
+## Algorithms
+
+- Search
+  - Best-of-N sampling
+  - Beam Search
+  - Lookahead search (MCTS with a frozen PRM)
+- Modelling
+  - ORM
+  - PRM
+  - Refinement
+    - Sequential
+    - Parallel
+  - Unsupervised Difficulty estimation
+
+## Benchmarks
+
+- MATH
+
+## Metric Results
+
+- How is quality measured?
+  - The quality is measured using Monte Carlo roll-outs from an step.
+- How is diversity measured?
+  - The diversity is measured using pass@1 rate for difficulty estimation.
+  - The diversity is also measured using character edit distance for revision data.
+- Fine-tuning results?
+  - PRM outperforms ORM specially at higher number of samples.
+  - Lookahead-search generally under-performs other methods at the same generation budget, likely due to the additional computation inducted by simulating the lookahead roll-outs.
+  - Beam search with PRM is more effective on hard questions and at lower compute budgets.
+  - Best-of-N with PRM is more effective on easier questions and at higher compute budgets.
+  - Harder questions performs well with a hybrid refinement (sequential and parallel).
+  - Purely sequential test-time refinement is more effective for easier questions.
+  - For harder questions, pre-training is more effective than test-time compute.
+  - For easy and medium questions, test-time compute can cover up for additional pre-training.
+
+## Paper Tags
+
+1. SAMPLING
+2. SEARCH
+3. SYNTH
+4. COMPLEXITY
+5. MOTIV
+
+## Relevant related work
+
+[1] Training revision models with synthetic data. Coming soon (Yet to be published), 2024.
+
+## Other comments
+
+
+## Questions
+
+Do the results generalize for other models than PaLM 2-S*? 
+Do the results generalize for other benchmarks?
+Can Lookahead-search be modified to make it work better than other search methods in this setup?


### PR DESCRIPTION
Added summary for [Scaling LLM Test-Time Compute Optimally can be More Effective than Scaling Model Parameters](https://arxiv.org/abs/2408.03314)

Closes #338